### PR TITLE
Superblock 과제 Refactor - 프론트엔드 최재원

### DIFF
--- a/src/balloonGame/Cell.tsx
+++ b/src/balloonGame/Cell.tsx
@@ -1,17 +1,28 @@
+import { memo } from "react";
 import styled from "styled-components";
 
 type Props = {
   hasBalloon: boolean;
-  onClick: () => void;
+  rowIndex: number;
+  columnIndex: number;
+  onClick: (rowIndex: number, colIndex: number) => void;
 };
 
-export default function Cell({ hasBalloon, onClick }: Props) {
+export default memo(function Cell({
+  hasBalloon,
+  rowIndex,
+  columnIndex,
+  onClick,
+}: Props) {
   return (
-    <StyledCell onClick={onClick} $hasBalloon={hasBalloon}>
+    <StyledCell
+      onClick={() => onClick(rowIndex, columnIndex)}
+      $hasBalloon={hasBalloon}
+    >
       {hasBalloon ? "🎈" : ""}
     </StyledCell>
   );
-}
+});
 
 const StyledCell = styled.div<{ $hasBalloon: boolean }>`
   display: flex;

--- a/src/balloonGame/GameBoard.tsx
+++ b/src/balloonGame/GameBoard.tsx
@@ -26,15 +26,16 @@ export default function GameBoard({
                 <Cell
                   key={`${rowIndex}-${columnIndex}`}
                   hasBalloon={hasBalloon}
-                  onClick={
-                    hasBalloon ? () => onClick(rowIndex, columnIndex) : () => {}
-                  }
+                  rowIndex={rowIndex}
+                  columnIndex={columnIndex}
+                  onClick={onClick}
                 />
               ))}
             </Row>
           ))}
         </div>
       </StyledGameBoard>
+
       {(isClear || isFailure) && (
         <Dialog
           isOpen={isClear || isFailure}

--- a/src/balloonGame/hook/useBalloonGame.ts
+++ b/src/balloonGame/hook/useBalloonGame.ts
@@ -30,7 +30,9 @@ export default function useBalloonGame({
 
       const grid = Array.from({ length: rows }, () =>
         Array.from({ length: columns }, () => {
-          const hasBalloon = Math.random() < probability;
+          const hasBalloon =
+            probability === 1 ? true : Math.random() < probability;
+
           if (hasBalloon) {
             balloonCount++;
           }
@@ -103,6 +105,15 @@ export default function useBalloonGame({
   );
 
   const onClick = (rowIndex: number, columnIndex: number) => {
+    if (probability === 1) {
+      const newGrid = Array.from({ length: rows }, () =>
+        Array.from({ length: columns }, () => false)
+      );
+
+      setGrid(newGrid);
+      return;
+    }
+
     const balloonGroup = getBalloonGroup(rowIndex, columnIndex);
 
     if (balloonCount[balloonCount.length - 1] === balloonGroup.length) {

--- a/src/balloonGame/hook/useBalloonGame.ts
+++ b/src/balloonGame/hook/useBalloonGame.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 const DIRECTIONS = [
   [-1, 0], // 상
@@ -56,6 +56,9 @@ export default function useBalloonGame({
   const [balloonCount, setBalloonCount] = useState<number[]>([]);
   const [isFailure, setIsFailure] = useState(false);
 
+  const gridRef = useRef(grid);
+  const balloonCountRef = useRef(balloonCount);
+
   const isClear = useMemo(
     () => grid.every((row) => row.every((cell) => cell === false)),
     [grid]
@@ -104,44 +107,16 @@ export default function useBalloonGame({
     [isValid]
   );
 
-  const onClick = (rowIndex: number, columnIndex: number) => {
-    if (probability === 1) {
-      const newGrid = Array.from({ length: rows }, () =>
+  const getBalloonGroup = useCallback(
+    (x: number, y: number) => {
+      const checkedGrid = Array.from({ length: rows }, () =>
         Array.from({ length: columns }, () => false)
       );
 
-      setGrid(newGrid);
-      return;
-    }
-
-    const balloonGroup = getBalloonGroup(rowIndex, columnIndex);
-
-    if (balloonCount[balloonCount.length - 1] === balloonGroup.length) {
-      const newGrid = [...grid];
-      balloonGroup.forEach(([x, y]) => (newGrid[x][y] = false));
-
-      setGrid(newGrid);
-      setBalloonCount(getBalloonCount(newGrid));
-    } else {
-      setIsFailure(true);
-    }
-  };
-
-  const onReset = () => {
-    const newGrid = generateGrid(rows, columns, probability);
-
-    setGrid(newGrid);
-    setBalloonCount(getBalloonCount(newGrid));
-    setIsFailure(false);
-  };
-
-  const getBalloonGroup = (x: number, y: number) => {
-    const checkedGrid = Array.from({ length: rows }, () =>
-      Array.from({ length: columns }, () => false)
-    );
-
-    return findGroup(grid, x, y, checkedGrid);
-  };
+      return findGroup(gridRef.current, x, y, checkedGrid);
+    },
+    [rows, columns, findGroup]
+  );
 
   const getBalloonCount = useCallback(
     (grid: boolean[][]) => {
@@ -173,12 +148,59 @@ export default function useBalloonGame({
     [rows, columns, findGroup, isValid]
   );
 
+  const onClick = useCallback(
+    (rowIndex: number, columnIndex: number) => {
+      if (probability === 1) {
+        const newGrid = Array.from({ length: rows }, () =>
+          Array.from({ length: columns }, () => false)
+        );
+
+        setGrid(newGrid);
+        return;
+      }
+
+      const balloonGroup = getBalloonGroup(rowIndex, columnIndex);
+
+      if (
+        balloonCountRef.current[balloonCountRef.current.length - 1] ===
+        balloonGroup.length
+      ) {
+        const newGrid = [...gridRef.current];
+        balloonGroup.forEach(([x, y]) => {
+          newGrid[x][y] = false;
+        });
+
+        setGrid(newGrid);
+        setBalloonCount(getBalloonCount(newGrid));
+      } else {
+        setIsFailure(true);
+      }
+    },
+    [rows, columns, probability, getBalloonGroup, getBalloonCount]
+  );
+
+  const onReset = () => {
+    const newGrid = generateGrid(rows, columns, probability);
+
+    setGrid(newGrid);
+    setBalloonCount(getBalloonCount(newGrid));
+    setIsFailure(false);
+  };
+
   useEffect(() => {
     const newGrid = generateGrid(rows, columns, probability);
 
     setGrid(newGrid);
     setBalloonCount(getBalloonCount(newGrid));
   }, [rows, columns, probability, generateGrid, getBalloonCount]);
+
+  useEffect(() => {
+    gridRef.current = grid;
+  }, [grid]);
+
+  useEffect(() => {
+    balloonCountRef.current = balloonCount;
+  }, [balloonCount]);
 
   return {
     grid,

--- a/src/balloonGame/hook/useBalloonGame.ts
+++ b/src/balloonGame/hook/useBalloonGame.ts
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+const DIRECTIONS = [
+  [-1, 0], // 상
+  [1, 0], // 하
+  [0, -1], // 좌
+  [0, 1], // 우
+];
+
 export type BalloonGameType = {
   rows?: number;
   columns?: number;
@@ -52,16 +59,6 @@ export default function useBalloonGame({
     [grid]
   );
 
-  const directions = useMemo(
-    () => [
-      [-1, 0], // 상
-      [1, 0], // 하
-      [0, -1], // 좌
-      [0, 1], // 우
-    ],
-    []
-  );
-
   const isValid = useCallback(
     (grid: boolean[][], x: number, y: number, checkedGrid: boolean[][]) => {
       return (
@@ -83,7 +80,7 @@ export default function useBalloonGame({
       group.push([x, y]);
       checkedGrid[x][y] = true;
 
-      directions.forEach((direction) => {
+      DIRECTIONS.forEach((direction) => {
         const current = [x + direction[0], y + direction[1]];
 
         if (isValid(grid, current[0], current[1], checkedGrid)) {
@@ -97,7 +94,7 @@ export default function useBalloonGame({
 
       return group;
     },
-    [directions, isValid]
+    [isValid]
   );
 
   const onClick = (rowIndex: number, columnIndex: number) => {

--- a/src/balloonGame/hook/useBalloonGame.ts
+++ b/src/balloonGame/hook/useBalloonGame.ts
@@ -76,21 +76,26 @@ export default function useBalloonGame({
   const findGroup = useCallback(
     (grid: boolean[][], x: number, y: number, checkedGrid: boolean[][]) => {
       const group: [number, number][] = [];
+      const queue = [[x, y]];
 
-      group.push([x, y]);
       checkedGrid[x][y] = true;
 
-      DIRECTIONS.forEach((direction) => {
-        const current = [x + direction[0], y + direction[1]];
+      while (queue.length > 0) {
+        const current = queue.shift()!;
+        group.push([current[0], current[1]]);
 
-        if (isValid(grid, current[0], current[1], checkedGrid)) {
-          checkedGrid[current[0]][current[1]] = true;
+        for (let i = 0; i < DIRECTIONS.length; i++) {
+          const direction = DIRECTIONS[i];
 
-          if (grid[current[0]][current[1]]) {
-            group.push(...findGroup(grid, current[0], current[1], checkedGrid));
+          const next_x = current[0] + direction[0];
+          const next_y = current[1] + direction[1];
+
+          if (isValid(grid, next_x, next_y, checkedGrid)) {
+            checkedGrid[next_x][next_y] = true;
+            queue.push([next_x, next_y]);
           }
         }
-      });
+      }
 
       return group;
     },


### PR DESCRIPTION
# Superblock 과제 Refactor  - 프론트엔드 최재원

## 실행
이전 dev 브랜치에서 변경점만 확인 가능하도록 **refactor 브랜치**에서 작업을 진행했습니다.
프로젝트 실행하기 전 브랜치를 확인 부탁드립니다.

```
git switch refactor 
npm i
npm run dev
```

## 요구사항 - 효율성 측면으로의 검토 및 개선 요청
## 1. RangeError : Maxmum call stack size exceeded
![image (10)](https://github.com/user-attachments/assets/df6f8864-3e48-43af-b921-d63c300cffd8)
- `rows`, `columns`, `probability`의 크기가 매우 커질 경우 다음과 같은 에러를 볼 수 있었습니다.
- ex) rows = 100, columns = 100, probability = 100
### 원인
- 기존 `findGroup` 함수는 셀 단위로 재귀적으로 호출되기 때문에, `rows`와 `columns`가 커질수록 호출 횟수가 증가하여 call stack에 많은 함수가 쌓이고, 해당 오류가 발생하게 됩니다.

### 해결
- `findGroup` 함수에서 재귀 호출을 제거하고, 연결된 셀의 좌표를 queue에 저장한 뒤, 해당 queue를 반복문으로 처리하는 방식으로 변경하였습니다.

## 2. 상태값 변경이 일어날 때 마다 모든 Cell의 재렌더링
- Cell 컴포넌트는 GameBoard 컴포넌트로부터 `basBalloon`과 `onClick` 두 가지 props를 전달받습니다.
- 여기서 `onClick`은 `useBallooneGame` 훅에서 전달받은 함수입니다.
- `onClick` 함수는 클릭 시 `grid` 상태를 변경하며, 이로 인해 `grid`를 의존성으로 가지게 됩니다.
- 즉, `onClick`이 실행되면 `grid`가 변경되고, `grid`의 의존성을 가진 `onClick`도 항상 새로운 함수로 갱신되기 때문에 useCallback을 사용 하더라도 모든 Cell 컴포넌트가 재렌더링됩니다.
- **결과적으로, onClick 실행 시 MxM개의 Cell 컴포넌트가 모두 재렌더링됩니다.**
- **이로 인해 grid 크기가 큰 경우, state 변경과 관련된 input 처리 및 Cell의 onClick 동작에서 성능 저하와 버벅거림이 발생하는 퍼포먼스 문제가 나타났습니다.**

### 접근 방식
- `onClick`과 `grid` 간의 강한 의존성으로 인해 둘을 분리하여 재렌더링을 방지하는 것이 어려웠습니다.
- 이 문제는 React의 `state`가 `비동기적`으로 변경된다는 특성 때문이라고 판단했습니다.
- 따라서  `useCallback`의 의존성 배열에 `grid`를 직접 추가하지 않으면서도, 항상 최신의 `grid`를 사용할 수 있는 방법을 고민했습니다.

### 해결
- 함수 내에서 사용하는 `grid`는 state이기 때문에, `useCallback`을 사용하여 메모이제이션하려면 `grid` 변경을 추적하기 위해 반드시 의존성 배열에 포함해야 합니다.
- 그러나 `ref`를 사용하면, `useCallback`으로 감싼 함수 내부에서 `ref`를 통해 `최신 값을 바로` 접근할 수 있어 의존성 배열에 추가할 필요가 없습니다.
``` typescript
  const [grid, setGrid] = useState(generateGrid(rows, columns, probability));
  const [balloonCount, setBalloonCount] = useState<number[]>([]);
  const [isFailure, setIsFailure] = useState(false);

  const gridRef = useRef(grid);
  const balloonCountRef = useRef(balloonCount);
  
  // 중략
  
  useEffect(() => {
    gridRef.current = grid;
  }, [grid]);

  useEffect(() => {
    balloonCountRef.current = balloonCount;
  }, [balloonCount]);

```
- 이렇게 추가함으로 hook에서 `grid`는 state를 그대로 제공하며, 내부에서 해당 값이 필요한 경우 `gridRef`를 통해서 사용합니다.
- `grid`를 변경해야 할 경우 `setGrid`를 사용하며, `useEffect`를 통해 `gridRef`를 최신 상태로 갱신하도록 처리했습니다.


<details>
<summary><h3>개선 전/후 비교 동영상</h3></summary> 
<h3>개선 전</h3>

https://github.com/user-attachments/assets/bbaf179e-21e9-4cc8-849d-482a7fcfe9e3

다량의 Cell이 모두 재렌더링되며 input의 입력 처리도 느려지는 상태

<h3>개선 후 </h3>

https://github.com/user-attachments/assets/f2df000c-4937-4556-bcbd-a833410eb871

개선전에 비해서 input 입력 처리가 빨라진 상태

</details>

### 문제점
- 이 이슈를 충분히 이해하지 못한 동료가 코드를 검토할 경우, `ref` 사용이 불필요해 보일 가능성이 있습니다.
- 만약 해당 훅을 리팩토링해야 한다면, 제가 설계해 둔 `state`와 `ref` 간의 동기화 로직을 충분히 이해하고, 이를 신경쓰며 관리해야 합니다.
- 이 두 가지 문제로 인해, 해당 이슈를 완벽히 이해하고 설계한 저를 제외한 다른 사람이 제 설계 방향성에 맞게 수정하는 데 어려움을 겪을 가능성이 있습니다.

### 결론
- 훅의 사용처에서 퍼포먼스 이슈가 발생할 만큼 큰 `grid` 크기를 사용하지 않는다면, `ref`를 제거하고 기본 `state`만으로 동작하도록 변경해도 무방할 것으로 보입니다.
- 다만, 과제에서 `grid`의 크기에 대한 별도의 제한이 명시되지 않았기 때문에, 제한을 따로 설정하지 않은 상태를 유지하며 재렌더링 문제를 해결하기 위해 `ref`를 도입한 것입니다.
- 만약 정말 큰 `grid`도 수용할 수 있도록 하는 기획 방향성을 따른다면, 해당 훅에 대해 더 상세한 문서와 주석을 작성하여 설계 의도와 구현 방식을 명확히 전달할 필요가 있을 것 같습니다.
