### PR TITLE
onClick 함수의 시간 복잡도 개선

### DIFF
--- a/src/balloonGame/Cell.tsx
+++ b/src/balloonGame/Cell.tsx
@@ -16,7 +16,7 @@ export default memo(function Cell({
 }: Props) {
   return (
     <StyledCell
-      onClick={() => onClick(rowIndex, columnIndex)}
+      onClick={hasBalloon ? () => onClick(rowIndex, columnIndex) : () => {}}
       $hasBalloon={hasBalloon}
     >
       {hasBalloon ? "🎈" : ""}

--- a/src/balloonGame/hook/useBalloonGame.ts
+++ b/src/balloonGame/hook/useBalloonGame.ts
@@ -58,6 +58,7 @@ export default function useBalloonGame({
 
   const gridRef = useRef(grid);
   const balloonCountRef = useRef(balloonCount);
+  const groupMap = useRef<Map<string, [number, number]> | null>(null);
 
   const isClear = useMemo(
     () => grid.every((row) => row.every((cell) => cell === false)),
@@ -107,20 +108,12 @@ export default function useBalloonGame({
     [isValid]
   );
 
-  const getBalloonGroup = useCallback(
-    (x: number, y: number) => {
-      const checkedGrid = Array.from({ length: rows }, () =>
-        Array.from({ length: columns }, () => false)
-      );
-
-      return findGroup(gridRef.current, x, y, checkedGrid);
-    },
-    [rows, columns, findGroup]
-  );
-
-  const getBalloonCount = useCallback(
+  const getBalloonInfo = useCallback(
     (grid: boolean[][]) => {
       const balloonCount: number[] = [];
+      const newGroupMap = new Map<string, [number, number]>();
+
+      let groupId = 0;
 
       const checkedGrid = Array.from({ length: rows }, () =>
         Array.from({ length: columns }, () => false)
@@ -129,21 +122,31 @@ export default function useBalloonGame({
       checkedGrid.forEach((rows, rowIndex) => {
         rows.forEach((_, columnIndex) => {
           if (isValid(grid, rowIndex, columnIndex, checkedGrid)) {
-            const ballonGroup = findGroup(
+            const balloonGroup = findGroup(
               grid,
               rowIndex,
               columnIndex,
               checkedGrid
             );
 
-            if (ballonGroup.length) {
-              balloonCount.push(ballonGroup.length);
+            if (balloonGroup.length) {
+              balloonCount.push(balloonGroup.length);
+
+              const currentGroupId = groupId++;
+              balloonGroup.forEach(([x, y]) => {
+                newGroupMap.set(`${x},${y}`, [
+                  balloonGroup.length,
+                  currentGroupId,
+                ]);
+              });
             }
           }
         });
       });
 
-      return balloonCount.sort((a, b) => a - b);
+      balloonCount.sort((a, b) => a - b);
+
+      return { balloonCount, ballonGroupMap: newGroupMap };
     },
     [rows, columns, findGroup, isValid]
   );
@@ -159,15 +162,27 @@ export default function useBalloonGame({
         return;
       }
 
-      const balloonGroup = getBalloonGroup(rowIndex, columnIndex);
+      const maxGroupCount =
+        balloonCountRef.current[balloonCountRef.current.length - 1];
 
-      if (
-        balloonCountRef.current[balloonCountRef.current.length - 1] ===
-        balloonGroup.length
-      ) {
+      const currentGroupInfo = groupMap.current?.get(
+        `${rowIndex},${columnIndex}`
+      );
+
+      if (!currentGroupInfo) {
+        setIsFailure(true);
+        return;
+      }
+
+      const [currentGroupCount, currentGroupId] = currentGroupInfo;
+
+      if (maxGroupCount === currentGroupCount) {
         const newGrid = [...gridRef.current];
-        balloonGroup.forEach(([x, y]) => {
-          newGrid[x][y] = false;
+        groupMap.current?.forEach(([_, groupId], key) => {
+          if (currentGroupId === groupId) {
+            const [x, y] = key.split(",").map(Number);
+            newGrid[x][y] = false;
+          }
         });
 
         setGrid(newGrid);
@@ -176,23 +191,29 @@ export default function useBalloonGame({
         setIsFailure(true);
       }
     },
-    [rows, columns, probability, getBalloonGroup, getBalloonCount]
+    [rows, columns, probability, getBalloonInfo]
   );
 
   const onReset = () => {
     const newGrid = generateGrid(rows, columns, probability);
+    const { balloonCount, ballonGroupMap } = getBalloonInfo(newGrid);
+
+    groupMap.current = ballonGroupMap;
 
     setGrid(newGrid);
-    setBalloonCount(getBalloonCount(newGrid));
+    setBalloonCount(balloonCount);
     setIsFailure(false);
   };
 
   useEffect(() => {
     const newGrid = generateGrid(rows, columns, probability);
+    const { balloonCount, ballonGroupMap } = getBalloonInfo(newGrid);
+
+    groupMap.current = ballonGroupMap;
 
     setGrid(newGrid);
-    setBalloonCount(getBalloonCount(newGrid));
-  }, [rows, columns, probability, generateGrid, getBalloonCount]);
+    setBalloonCount(balloonCount);
+  }, [rows, columns, probability, generateGrid, getBalloonInfo]);
 
   useEffect(() => {
     gridRef.current = grid;
@@ -206,6 +227,7 @@ export default function useBalloonGame({
     grid,
     isClear,
     isFailure,
+    groupMap,
     onClick,
     onReset,
   };

--- a/src/balloonGame/hook/useBalloonGame.ts
+++ b/src/balloonGame/hook/useBalloonGame.ts
@@ -171,7 +171,7 @@ export default function useBalloonGame({
         });
 
         setGrid(newGrid);
-        setBalloonCount(getBalloonCount(newGrid));
+        setBalloonCount(balloonCountRef.current.slice(0, -1));
       } else {
         setIsFailure(true);
       }


### PR DESCRIPTION
## onClick 함수의 시간 복잡도 문제 개선
### onClick의 시간 복잡도
``` typescript
// onClick 함수의 일부
// 신경 쓰지 않아도 되는 부분은 생략..

const balloonGroup = getBalloonGroup(rowIndex, columnIndex);
// getBalloonGroup은 모든 grid를 순회하며 해당 cell의 상하좌우를 체크한다.
// 대략 O((row * column) * 4)

if (
  balloonCountRef.current[balloonCountRef.current.length - 1] ===
  balloonGroup.length
) {
  const newGrid = [...gridRef.current];
  // 스프레드로 복사 - O(column)
  balloonGroup.forEach(([x, y]) => {
    newGrid[x][y] = false;
  });
  // O(n)

  setGrid(newGrid);
  setBalloonCount(getBalloonCount(newGrid));
  // getBalloonCount는 모든 grid를 순회하며 모든 group의 카운트를 계산한다.
  // 실행될 때마다 O((row * column)^2)
}

```
- 즉, onClick이 실행될 때마다 엄청난 횟수의 grid 순회가 발생하고 있습니다.

## 첫 번째 시도 : 실패
- 피드백을 받은 후, 해당 문제를 해결하기 위해 onClick이 실행될 때 계산하는 로직을 게임을 생성할 때 미리 계산해 놓는 방법으로 접근했습니다.
- `[[[1][2], [2][3], [3][4]], [[5][6], [6][7], [7][8]]]`와 같이 기존 findGroup에서 제공해주는 group을 그대로 배열로 wrapping하여 가지고 있는 방식이었습니다.
- 위 배열을 length 순으로 sort하면 가장 많은 개수를 가진 group이 될 것이고, 그럼 첫 번째 배열에 x, y 좌표가 있는지 확인하면 될 것이라 생각했습니다.
- 이렇게 시도하는 계획을 이야기했을 때, length가 동일한 즉, group의 개수가 같은 경우 어떻게 처리할지에 대한 질문을 받았고, **첫 번째 배열에서 찾지 못하면 다음 배열로, 또 그다음 배열로 순회해야 하는 상황이 발생함을 알게 되었습니다.**
## 두 번째 시도 : 성공
- onClick 문제의 핵심은 `setBalloonCount(getBalloonCount(newGrid));`였습니다.
- onClick에서 `setBalloonCount(getBalloonCount(newGrid));`를 사용하는 이유는 풍선을 터뜨려 해당 그룹의 개수를 balloonCount에서 제외하기 위해서였습니다.
- 기존에는 새로운 grid로 전체 balloonCount를 다시 계산하는 방식이었지만, 이 로직은 필요하지 않았습니다.
- 대신 `setBalloonCount(balloonCountRef.current.slice(0, -1));`로 마지막 값을 제외하는 방식으로 변경하여, 시간 복잡도 `O((row * column)^2)`를 제거했습니다.

<details>
<summary><h3>getBalloonCount 개선 전/후 onClick 실행 시간</h3></summary> 
<h4>`performance.now();`를 사용해 onClick의 실행 직후, 종료 직전에 배치하여 둘의 차이로 계산 했습니다.</h4>
<h4>grid의 크기는 80 * 80으로 진행했습니다.</h4>
<h3>개선 전</h3>

![test1-2](https://github.com/user-attachments/assets/178daff7-8721-468c-af32-278eed0fdf56)

10회 실행 - 평균 약 1.4096ms

<h3>개선 후 </h3>

![test2-2](https://github.com/user-attachments/assets/344f10a6-9268-4791-b912-257e46c16dcc)

10회 실행 - 평균 약 0.4098ms

<h3>1.4096ms -> 0.4098ms 약 70% 개선</h3>

</details>

## 세 번째 시도 : 성공
- onClick이 실행될 때 클릭된 좌표를 받아 해당 좌표의 그룹을 계산하는 `const balloonGroup = getBalloonGroup(rowIndex, columnIndex);`을 매번 실행하고 있었습니다.
- 첫 번째 시도에서 생각했던 대로, 게임 생성 시에 미리 모든 그룹을 계산해 놓고 저장해 두면 onClick에서는 계산할 필요가 없다고 판단했습니다.
- 배열을 순회해서 찾는 것은 시간 복잡도 개선이 미미하거나 불가능할 수 있기 때문에, Map을 사용하기로 했습니다.
- groupMap이라는 ref를 만들어 `"row, column"` 형태의 문자열을 key로 사용하고, value로 `[groupCount, groupId]`를 리턴하도록 했습니다.
- Map을 사용함으로써 좌표를 이용해 `O(1)`의 시간 복잡도로 해당 좌표의 count와 id로 어떤 group에 속해 있는지 확인할 수 있었습니다.
- `groupId`를 추가한 이유는, count가 동일하지만 다른 group이 있을 수 있기 때문에 동일한 group만 grid에서 삭제할 수 있도록 하기 위함입니다.
- `getBalloonGroup` 함수명을 `getBalloonInfo`로 변경하여 `{ balloonCount, balloonGroupMap }`을 리턴하도록 했습니다.

<details>
<summary><h3>getBalloonGroup 개선 전/후 onClick 실행 시간</h3></summary> 
<h4>`performance.now();`를 사용해 onClick의 실행 직후, 종료 직전에 배치하여 둘의 차이로 계산 했습니다.</h4>
<h4>grid의 크기는 80 * 80으로 진행했습니다.</h4>

<h3>개선 전</h3>

![test2-2](https://github.com/user-attachments/assets/81046f52-1cd3-4ac8-bac3-f7fd199a44c4)


10회 실행 - 평균 약 0.4098ms

<h3>개선 후 </h3>

![test3-2](https://github.com/user-attachments/assets/186044c6-644f-4322-9a14-258728d4d9f4)

10회 실행 - 평균 약 0.2695ms

<h3>0.4098ms - 0.2695ms 약 34% 추가 개선</h3>

</details>

<details>
<summary><h3>개선 후 onClick의 시간 복잡도</h3></summary> 

``` typescript
// onClick 함수의 일부
// 신경쓰지 않아도 되는 부분은 생략..

const maxGroupCount =
  balloonCountRef.current[balloonCountRef.current.length - 1];

const currentGroupInfo = groupMap.current?.get(
  `${rowIndex},${columnIndex}`
);
// O(1)

if (!currentGroupInfo) {
  setIsFailure(true);
  return;
}

const [currentGroupCount, currentGroupId] = currentGroupInfo;

if (maxGroupCount === currentGroupCount) {
  const newGrid = [...gridRef.current];
  // 스프레드로 복사 - O(column)
  groupMap.current?.forEach(([_, groupId], key) => {
    if (currentGroupId === groupId) {
      const [x, y] = key.split(",").map(Number);
      newGrid[x][y] = false;
    }
  });
  // O(n)

  setGrid(newGrid);
  setBalloonCount(balloonCountRef.current.slice(0, -1));
  // O(balloonCountRef.length)
}

```
</details>

## 결론
- 매 onClick 실행 시 계산되던 로직을 게임 생성 시에 미리 계산하도록 변경했습니다.
- 그 결과, 모든 계산된 정보를 저장하는 메모리 사용량이 증가했지만, 유저의 행동에 대한 딜레이를 크게 개선할 수 있었습니다.
- Space–Time tradeoff가 발생했지만, 개선 전과 최종 결과에서 `약 80%의 속도 개선`을 이뤘습니다.
- ~부족한 디테일에 대한 시야가 넓어진 기분~